### PR TITLE
closes #21 fix token access from publish-npm action

### DIFF
--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -6,8 +6,8 @@ runs:
     - name: Release
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
+        NPM_TOKEN: ${{ github.token }}
       run: npx semantic-release
 
     # - name: Publish


### PR DESCRIPTION
Swap secrets.GITHUB_TOKEN to github.token to resolve token access from pipeline action fixes #21 

Signed-off-by: Bruno DUVAL <48152847+datatunning@users.noreply.github.com>